### PR TITLE
fix: Remove eval() usage and add audio safety check

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -28,7 +28,9 @@ WHISPER_FEAT_CFG = {
 
 def get_audio_token_length(seconds, merge_factor=2):
     def get_T_after_cnn(L_in, dilation=1):
-        for padding, kernel_size, stride in eval("[(1,3,1)] + [(1,3,2)] "):
+        # CNN layer configurations: (padding, kernel_size, stride)
+        layer_configs = [(1, 3, 1), (1, 3, 2)]
+        for padding, kernel_size, stride in layer_configs:
             L_out = L_in + 2 * padding - dilation * (kernel_size - 1) - 1
             L_out = 1 + L_out // stride
             L_in = L_out
@@ -56,6 +58,10 @@ def build_prompt(
     wav = wav[:1, :]
     if sr != feature_extractor.sampling_rate:
         wav = torchaudio.transforms.Resample(sr, feature_extractor.sampling_rate)(wav)
+
+    # Check if audio is empty
+    if wav.shape[1] == 0:
+        raise ValueError(f"Audio file is empty or has no samples: {audio_path}")
 
     tokens = []
     tokens += tokenizer.encode("<|user|>")


### PR DESCRIPTION
## Summary

This PR fixes two code quality and safety issues in `inference.py`:

1. **Remove unnecessary `eval()` call**
2. **Add explicit empty audio validation**

## Issues Fixed

### 1. Remove eval() in get_audio_token_length()

**Problem:** Line 31 used `eval()` to create a hardcoded list literal:
```python
for padding, kernel_size, stride in eval("[(1,3,1)] + [(1,3,2)] "):
```

**Why this is problematic:**
- **Security risk**: Using `eval()` is a code smell and potential security vulnerability
- **Unnecessary overhead**: Parsing and evaluating a string at runtime adds overhead
- **Poor readability**: Makes the code harder to understand and maintain
- **Bad practice**: Even with hardcoded input, using `eval()` encourages poor coding patterns

**Solution:** Replaced with a direct list variable:
```python
# CNN layer configurations: (padding, kernel_size, stride)
layer_configs = [(1, 3, 1), (1, 3, 2)]
for padding, kernel_size, stride in layer_configs:
```

### 2. Add Empty Audio Check

**Problem:** If an audio file is empty (0 samples), the code would fail later during processing with an unclear error message: "音频内容为空或加载失败" (Audio content is empty or failed to load).

**Solution:** Added explicit validation early in `build_prompt()`:
```python
# Check if audio is empty
if wav.shape[1] == 0:
    raise ValueError(f"Audio file is empty or has no samples: {audio_path}")
```

**Benefits:**
- Fails fast with a clear error message
- Includes the problematic audio file path in the error
- Easier to debug issues with audio files

## Impact

- **Low risk**: Only changes internal implementation, no API changes
- **Improved safety**: Removes eval() usage
- **Better UX**: Clearer error messages for debugging
- **Code quality**: More maintainable and readable code

## Test plan

- [x] Code changes maintain same functionality
- [x] eval() replacement produces identical results
- [x] Empty audio check provides better error message
- [x] No behavioral changes for valid audio files

🤖 Generated with [Claude Code](https://claude.com/claude-code)